### PR TITLE
Remove .js in package.json > export > dafault 

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "exports": {
     "require": {
       "types": "./jssm.es5.d.cts",
-      "default": "./dist/jssm.es5.cjs.js"
+      "default": "./dist/jssm.es5.cjs"
     },
     "import": {
       "types": "./jssm.es6.d.ts",


### PR DESCRIPTION
Updating package.json because the file "jssm/dist/jssm.es5.cjs.js" doesn't exist but the file "jssm/dist/jssm.es5.cjs" exist.

<img width="287" alt="Screenshot 2025-04-03 at 10 01 30 am" src="https://github.com/user-attachments/assets/dfeb1c41-80de-4523-8f85-fba3b7629b38" />
