### PR TITLE
fix: remove duplicate γ alternative in JsNumericLiteral (#584)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,5 @@ docs/docs/*.css.map
 
 .claude
 .superpowers
+
+.worktrees

--- a/src/ts/fsl_parser.peg
+++ b/src/ts/fsl_parser.peg
@@ -363,9 +363,8 @@ JsNumericLiteral "number"
   / 'ϕ'                              { return 1.61803398874989484820; }
   / 'φ'                              { return 1.61803398874989484820; }
   / 'EulerConstant'                  { return 0.57721566490153286060; }
-  / 'γ'                              { return 0.57721566490153286060; }
-  / '𝛾'                              { return 0.57721566490153286060; }
-  / 'γ'                              { return 0.57721566490153286060; }
+  / 'γ'                              { return 0.57721566490153286060; }            // greek small letter gamma U+03B3
+  / '𝛾'                              { return 0.57721566490153286060; }            // mathematical italic small gamma U+1D6FE
 
 JsDecimalLiteral
   = JsDecimalIntegerLiteral "." DecimalDigit* JsNExponentPart? { return parseFloat(text()); }


### PR DESCRIPTION
## Summary

- Removes a duplicate `'γ'` literal in the `JsNumericLiteral` rule of `src/ts/fsl_parser.peg`. Lines 366 and 368 both contained U+03B3, so line 368 was unreachable under PEG ordered choice.
- Adds short codepoint comments (`U+03B3`, `U+1D6FE`) to the surviving two alternatives so the next reader can tell the visually-similar gamma forms apart at a glance — this is the same convention used elsewhere in the file (see lines 338–339 for the Epsilon block).
- Adds `.worktrees` to `.gitignore` so locally-created worktrees don't pollute `git status`.

Fixes #584

## Test plan

- [x] `pegjs` compiles the modified grammar without error.
- [x] No other rule in the grammar references the deleted alternative — it was an inline literal with no name.
- [ ] CI test suite (Jest spec + stoch) passes — verifying via this PR's checks.

## Notes for the reviewer

The duplicate alternative produced no observable wrong-output bug for any input the grammar previously accepted; the issue is the *missing* third Unicode variant the entry was apparently meant to introduce. If you recall the originally-intended Unicode form (e.g. `ɣ` U+0263, `Γ` U+0393, `𝛤` U+1D6E4, `ℽ` U+213D, or one of the bold/italic math gammas), happy to follow up with a separate PR adding it back as a real third alternative. This PR keeps the change minimal and structurally honest about what the rule actually accepts today.