### PR TITLE
feat(viz): add optional dot footer arg to render entry points

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jssm",
-  "version": "5.112.4",
+  "version": "5.113.0",
   "engines": {
     "node": ">=10.0.0"
   },

--- a/src/ts/jssm_viz.ts
+++ b/src/ts/jssm_viz.ts
@@ -241,9 +241,24 @@ function flow_direction_to_rankdir(flow_direction: string): string {
 /**
  *  Build the graphviz `digraph G { ... }` envelope from rendered fragments.
  *
+ *  The optional `preamble` is inlined just after `digraph G {`, before any
+ *  graph attributes; the optional `footer` is inlined just before the closing
+ *  `}`, after all arrange declarations.  Both are emitted verbatim, separated
+ *  from surrounding content by a blank line so that empty strings render
+ *  cleanly (no stray whitespace artifacts in the output).
+ *
+ *  @param rank_dir Pre-rendered `rankdir=...;` fragment (see {@link flow_direction_to_rankdir}).
+ *  @param graph_bg_color CSS-style color string for `bgcolor`.
+ *  @param nodes Rendered node-declaration block.
+ *  @param edges Rendered edge-declaration block.
+ *  @param arranges Rendered rank-arrangement block.
+ *  @param preamble Optional verbatim dot source inserted just after `digraph G {`.
+ *  @param footer Optional verbatim dot source inserted just before the closing `}`.
+ *  @returns A complete graphviz dot source string.
+ *
  *  @internal
  */
-function dot_template(rank_dir: string, graph_bg_color: string, nodes: string, edges: string, arranges: string, preamble = ''): string {
+function dot_template(rank_dir: string, graph_bg_color: string, nodes: string, edges: string, arranges: string, preamble = '', footer = ''): string {
   return `digraph G {
 ${preamble}
 
@@ -259,6 +274,8 @@ ${nodes}
 ${edges}
 
 ${arranges}
+
+${footer}
 }`;
 }
 
@@ -557,18 +574,28 @@ function arranges_for<T>(u_jssm: jssm.Machine<T>, state_index: Map<string, numbe
 /**
  *  Render a {@link jssm.Machine} as a graphviz dot string.
  *
+ *  An optional `footer` may be supplied via `opts.footer`; it is emitted
+ *  verbatim just before the closing `}` of the dot source, after all
+ *  arrange declarations.  This is a function-argument-only feature for
+ *  the moment — a machine-attribute equivalent is planned as a follow-up.
+ *
  *  ```typescript
  *  import { sm } from 'jssm';
  *  import { machine_to_dot } from 'jssm/viz';
  *
  *  const dot = machine_to_dot(sm`a -> b;`);
  *  // 'digraph G { ... }'
+ *
+ *  const dot_with_footer = machine_to_dot(sm`a -> b;`, { footer: 'labelloc="b"; label="caption";' });
+ *  // 'digraph G { ... labelloc="b"; label="caption"; }'
  *  ```
  *
  *  @param u_jssm The machine to render.
+ *  @param opts Optional rendering options.
+ *  @param opts.footer Optional verbatim dot source inserted just before the closing `}`.
  *  @returns A complete graphviz dot source string.
  */
-function machine_to_dot<T>(u_jssm: jssm.Machine<T>): string {
+function machine_to_dot<T>(u_jssm: jssm.Machine<T>, opts?: { footer?: string }): string {
 
   const l_states    = u_jssm.states();
   const state_index = new Map<string, number>(l_states.map((s, i) => [s, i] as [string, number]));
@@ -580,8 +607,9 @@ function machine_to_dot<T>(u_jssm: jssm.Machine<T>): string {
 
   const rank_dir = flow_direction_to_rankdir(u_jssm.flow() || 'down');
   const preamble = u_jssm.dot_preamble() || '';
+  const footer   = opts?.footer ?? '';
 
-  return dot_template(rank_dir, vc('graph_bg_color'), nodes, edges, arranges, preamble);
+  return dot_template(rank_dir, vc('graph_bg_color'), nodes, edges, arranges, preamble, footer);
 
 }
 
@@ -594,13 +622,18 @@ function machine_to_dot<T>(u_jssm: jssm.Machine<T>): string {
  *  ```typescript
  *  import { fsl_to_dot } from 'jssm/viz';
  *  const dot = fsl_to_dot('a -> b;');
+ *
+ *  const dot_with_footer = fsl_to_dot('a -> b;', { footer: 'label="caption";' });
+ *  // 'digraph G { ... label="caption"; }'
  *  ```
  *
  *  @param fsl The FSL source.
+ *  @param opts Optional rendering options.
+ *  @param opts.footer Optional verbatim dot source inserted just before the closing `}`.
  *  @returns A complete graphviz dot source string.
  */
-function fsl_to_dot(fsl: string): string {
-  return machine_to_dot(jssm.sm`${fsl}`);
+function fsl_to_dot(fsl: string, opts?: { footer?: string }): string {
+  return machine_to_dot(jssm.sm`${fsl}`, opts);
 }
 
 
@@ -630,10 +663,12 @@ async function dot_to_svg(dot: string): Promise<string> {
  *  Render an FSL string directly to SVG.
  *
  *  @param fsl The FSL source.
+ *  @param opts Optional rendering options.
+ *  @param opts.footer Optional verbatim dot source inserted just before the closing `}` of the intermediate dot source.
  *  @returns A promise resolving to an SVG XML string.
  */
-async function fsl_to_svg_string(fsl: string): Promise<string> {
-  return dot_to_svg(fsl_to_dot(fsl));
+async function fsl_to_svg_string(fsl: string, opts?: { footer?: string }): Promise<string> {
+  return dot_to_svg(fsl_to_dot(fsl, opts));
 }
 
 
@@ -643,10 +678,12 @@ async function fsl_to_svg_string(fsl: string): Promise<string> {
  *  Render a {@link jssm.Machine} to SVG.
  *
  *  @param u_jssm The machine to render.
+ *  @param opts Optional rendering options.
+ *  @param opts.footer Optional verbatim dot source inserted just before the closing `}` of the intermediate dot source.
  *  @returns A promise resolving to an SVG XML string.
  */
-async function machine_to_svg_string<T>(u_jssm: jssm.Machine<T>): Promise<string> {
-  return dot_to_svg(machine_to_dot(u_jssm));
+async function machine_to_svg_string<T>(u_jssm: jssm.Machine<T>, opts?: { footer?: string }): Promise<string> {
+  return dot_to_svg(machine_to_dot(u_jssm, opts));
 }
 
 
@@ -692,11 +729,13 @@ async function dot_to_svg_element(dot: string): Promise<SVGSVGElement> {
  *  Render an FSL string directly to a parsed `SVGSVGElement`.
  *
  *  @param fsl The FSL source.
+ *  @param opts Optional rendering options.
+ *  @param opts.footer Optional verbatim dot source inserted just before the closing `}` of the intermediate dot source.
  *  @returns A promise resolving to a parsed `SVGSVGElement`.
  *  @throws {JssmError} if no `DOMParser` is available (Node without `configure`).
  */
-async function fsl_to_svg_element(fsl: string): Promise<SVGSVGElement> {
-  return dot_to_svg_element(fsl_to_dot(fsl));
+async function fsl_to_svg_element(fsl: string, opts?: { footer?: string }): Promise<SVGSVGElement> {
+  return dot_to_svg_element(fsl_to_dot(fsl, opts));
 }
 
 
@@ -706,11 +745,13 @@ async function fsl_to_svg_element(fsl: string): Promise<SVGSVGElement> {
  *  Render a {@link jssm.Machine} to a parsed `SVGSVGElement`.
  *
  *  @param u_jssm The machine to render.
+ *  @param opts Optional rendering options.
+ *  @param opts.footer Optional verbatim dot source inserted just before the closing `}` of the intermediate dot source.
  *  @returns A promise resolving to a parsed `SVGSVGElement`.
  *  @throws {JssmError} if no `DOMParser` is available (Node without `configure`).
  */
-async function machine_to_svg_element<T>(u_jssm: jssm.Machine<T>): Promise<SVGSVGElement> {
-  return dot_to_svg_element(machine_to_dot(u_jssm));
+async function machine_to_svg_element<T>(u_jssm: jssm.Machine<T>, opts?: { footer?: string }): Promise<SVGSVGElement> {
+  return dot_to_svg_element(machine_to_dot(u_jssm, opts));
 }
 
 

--- a/src/ts/tests/dot_footer.spec.ts
+++ b/src/ts/tests/dot_footer.spec.ts
@@ -1,0 +1,95 @@
+
+/* eslint-disable max-len */
+
+import * as jv   from '../jssm_viz';
+import * as jssm from '../jssm';
+
+const sm = jssm.sm;
+
+
+
+
+
+describe('Dot footer (no footer)', () => {
+
+  test('machine_to_dot without footer omits any extra trailing text', () => {
+    const dot = jv.machine_to_dot(sm`a -> b;`);
+    // closing brace appears, and no stray identifier is emitted between
+    // the last arrange-rank group and `}`
+    expect(dot).toMatch(/^digraph G \{/);
+    expect(dot).toMatch(/\}\s*$/);
+    expect(dot).not.toMatch(/CAPTION_FOOTER/);
+  });
+
+  test('machine_to_dot with explicit empty-opts is equivalent to no opts', () => {
+    const a = jv.machine_to_dot(sm`a -> b;`);
+    const b = jv.machine_to_dot(sm`a -> b;`, {});
+    expect(a).toBe(b);
+  });
+
+  test('fsl_to_dot without footer omits any extra trailing text', () => {
+    const dot = jv.fsl_to_dot('a -> b;');
+    expect(dot).not.toMatch(/CAPTION_FOOTER/);
+  });
+
+});
+
+
+
+describe('Dot footer (footer present)', () => {
+
+  test('machine_to_dot includes footer text verbatim', () => {
+    const dot = jv.machine_to_dot(sm`a -> b;`, { footer: 'label="CAPTION_FOOTER";' });
+    expect(dot).toMatch(/label="CAPTION_FOOTER";/);
+  });
+
+  test('fsl_to_dot includes footer text verbatim', () => {
+    const dot = jv.fsl_to_dot('a -> b;', { footer: 'label="CAPTION_FOOTER";' });
+    expect(dot).toMatch(/label="CAPTION_FOOTER";/);
+  });
+
+  test('footer appears after the closing of arrange/edge content and before final `}`', () => {
+    const dot = jv.machine_to_dot(sm`a -> b;`, { footer: 'label="CAPTION_FOOTER";' });
+    const footer_idx = dot.indexOf('CAPTION_FOOTER');
+    const last_brace = dot.lastIndexOf('}');
+    expect(footer_idx).toBeGreaterThan(-1);
+    expect(footer_idx).toBeLessThan(last_brace);
+  });
+
+});
+
+
+
+describe('Dot footer (multiline)', () => {
+
+  test('multiline footer is preserved verbatim', () => {
+    const multi = 'labelloc="b";\nlabel="ALPHA_LINE\\nBETA_LINE";';
+    const dot   = jv.machine_to_dot(sm`a -> b;`, { footer: multi });
+    expect(dot).toMatch(/labelloc="b";/);
+    expect(dot).toMatch(/label="ALPHA_LINE\\nBETA_LINE";/);
+  });
+
+});
+
+
+
+describe('Dot footer composes with preamble', () => {
+
+  test('both preamble (from FSL) and footer (from opts) appear in output', () => {
+    const dot = jv.machine_to_dot(
+      sm`dot_preamble: "PREAMBLE_TOKEN"; a -> b;`,
+      { footer: 'FOOTER_TOKEN' }
+    );
+    expect(dot).toMatch(/PREAMBLE_TOKEN/);
+    expect(dot).toMatch(/FOOTER_TOKEN/);
+    // preamble must precede footer in source order
+    expect(dot.indexOf('PREAMBLE_TOKEN')).toBeLessThan(dot.indexOf('FOOTER_TOKEN'));
+  });
+
+  test('preamble alone (no footer arg) still renders the preamble token', () => {
+    const dot = jv.machine_to_dot(sm`dot_preamble: "PREAMBLE_TOKEN"; a -> b;`);
+    expect(dot).toMatch(/PREAMBLE_TOKEN/);
+    expect(dot).not.toMatch(/FOOTER_TOKEN/);
+  });
+
+});


### PR DESCRIPTION
Adds an `opts.footer` parameter to `machine_to_dot`, `fsl_to_dot`, and the four SVG variants (`fsl_to_svg_string`, `machine_to_svg_string`, `fsl_to_svg_element`, `machine_to_svg_element`), plus a trailing `footer` parameter to the internal `dot_template`. The footer is emitted verbatim just before the closing `}` of the dot source, mirroring the existing `preamble` slot. All existing call sites compile unchanged (parameter is optional).

Closes stonecypher/fsl#332.