### PR TITLE
fix(v6): ship the jssm/cli subpath (files allowlist) on v6

### DIFF
--- a/package.json
+++ b/package.json
@@ -99,6 +99,8 @@
     "dist/wc/instance.define.js",
     "dist/cdn/viz.js",
     "dist/cdn/instance.js",
+    "dist/cli/lib.cjs",
+    "dist/cli/lib.mjs",
     "dist/deno/jssm.js",
     "dist/deno/*.d.ts",
     "dist/deno/README.md",
@@ -106,6 +108,8 @@
     "jssm.es6.d.ts",
     "jssm_viz.es5.d.cts",
     "jssm_viz.es6.d.ts",
+    "jssm.cli.d.cts",
+    "jssm.cli.d.ts",
     "MIGRATING-jssm-viz.md",
     "custom-elements.json"
   ],


### PR DESCRIPTION
Same packaging omission as main #768, applied to v6: the `./cli` export targets (`dist/cli/lib.*`, `jssm.cli.d.*`) were absent from `files[]`, so the 6.0.0-alpha line would publish a broken `jssm/cli` subpath. Adds the four targets.

(Split out from #769, which already merged — this is the remaining cli-packaging piece for v6.) No build/version bump; non-runtime packaging metadata only.