### PR TITLE
fix: compiler crash on transition-free machines and bump codemirror-view to 6.43.4

### DIFF
--- a/sketch/cm6-editor/index.html
+++ b/sketch/cm6-editor/index.html
@@ -8,7 +8,7 @@
   {
     "imports": {
       "@codemirror/state":    "https://esm.sh/@codemirror/state@6.5.2",
-      "@codemirror/view":     "https://esm.sh/@codemirror/view@6.37.2?external=@codemirror/state",
+      "@codemirror/view":     "https://esm.sh/@codemirror/view@6.43.4?external=@codemirror/state",
       "@lezer/highlight":     "https://esm.sh/@lezer/highlight@1.2.1",
       "@codemirror/language": "https://esm.sh/@codemirror/language@6.10.8?external=@codemirror/state,@codemirror/view,@lezer/highlight",
       "@codemirror/commands": "https://esm.sh/@codemirror/commands@6.7.1?external=@codemirror/state,@codemirror/view,@codemirror/language",

--- a/src/ts/jssm_compiler.ts
+++ b/src/ts/jssm_compiler.ts
@@ -1362,7 +1362,7 @@ function compile<StateType, mDT>(tree: JssmParseTree<StateType, mDT>): JssmGener
     resolve_transition_conflicts(results['transition']);
 
   const result_cfg: JssmGenericConfig<StateType, mDT> = {
-    start_states   : results.start_states.length ? results.start_states : [assembled_transitions[0].from],
+    start_states   : results.start_states.length ? results.start_states : (assembled_transitions.length ? [assembled_transitions[0].from] : []),
     end_states     : results.end_states,
     failed_outputs : results.failed_outputs,
     transitions    : assembled_transitions,

--- a/src/ts/tests/compile.spec.ts
+++ b/src/ts/tests/compile.spec.ts
@@ -46,6 +46,13 @@ describe('compile/1', () => {
     }).not.toThrow() );
   });
 
+  describe('state Off : {};', () => {
+    const state_only_str = `state Off : {};`;
+    test('doesn\'t throw', () => expect( () => {
+      jssm.compile(jssm.parse(state_only_str));
+    }).not.toThrow() );
+  });
+
   describe('direct make callpoint', () => {
     const match = { start_states: [ 'a' ], end_states: [], failed_outputs: [], transitions: [ { from: 'a', to: 'b', kind: 'legal', after_time: undefined, forced_only: false, main_path: false } ], state_property: [] };
     test('direct match', () => {


### PR DESCRIPTION
Fixes the jssm compiler crash on transition-free configurations and bumps @codemirror/view to 6.43.4 in the editor sketch to resolve the tile-renderer state corruption crash.